### PR TITLE
Code optimizations for speed

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.5
+julia 0.6

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat
+Compat 0.17

--- a/src/SubsetSelection.jl
+++ b/src/SubsetSelection.jl
@@ -108,13 +108,13 @@ function subsetSelection(ℓ::LossFunction, Card::Sparsity, Y, X;
 
     #Gradient ascent on α
     for inner_iter in 1:min(gradUp, div(p, length(indices)))
-      α = α + δ*grad_dual(ℓ, Y, X, α, indices, γ)
+      α .+= δ .* grad_dual(ℓ, Y, X, α, indices, γ)
       α = proj_dual(ℓ, Y, α)
       α = proj_intercept(intercept, α)
     end
 
     #Update average a
-    a = (iter-1)/(iter)*a + 1/iter*α
+    @. a = (iter - 1) / iter * a + 1 / iter * α
 
     #Minimization w.r.t. s
     indices_old = indices[:]
@@ -206,7 +206,8 @@ function grad_dual(ℓ::LossFunction, Y, X, α, indices, γ)
     g[i] = - grad_fenchel(ℓ, Y[i], α[i])
   end
   for j in indices
-    g -= γ*dot(X[:,j], α)*X[:,j]
+    x = @view(X[:, j])
+    @. g -= γ * dot(x, α) * x
   end
   return g
 end

--- a/src/SubsetSelection.jl
+++ b/src/SubsetSelection.jl
@@ -30,7 +30,7 @@ abstract Classification <: LossFunction
 abstract Sparsity
   #Constraint: add the constraint "s.t. ||w||_0<=k"
   immutable Constraint <: Sparsity
-    k::Integer
+    k::Int
   end
   function parameter(Card::Constraint)
     return Card.k

--- a/src/SubsetSelection.jl
+++ b/src/SubsetSelection.jl
@@ -270,8 +270,8 @@ end
 ##Projection of α on e^T α = 0 (if intercept)
 function proj_intercept(intercept::Bool, α)
   if intercept
-    n = size(α, 1)
-    return α - dot(α, ones(n))/n*ones(n)
+    α .-= mean(α)
+    return α
   else
     return α
   end
@@ -302,9 +302,10 @@ function partial_min(Card::Penalty, X, α, γ)
 end
 
 ##Bias term
-function compute_bias(ℓ::LossFunction, Y, X, α, indices, γ, intercept::Bool)
+function compute_bias(ℓ::LossFunction, Y, X, α, indices, n_indices, γ,
+                      intercept::Bool, cache::Cache)
   if intercept
-    g = grad_dual(ℓ, Y, X, α, indices, γ)
+    g = grad_dual(ℓ, Y, X, α, indices, n_indices, γ, cache)
     return (minimum(g[α != 0.]) + maximum(g[α != 0.]))/2
   else
     return 0.

--- a/src/SubsetSelection.jl
+++ b/src/SubsetSelection.jl
@@ -299,9 +299,24 @@ function partial_min!(indices, Card::Constraint, X, α, γ, cache::Cache)
   # Return the updated size of indices
   return n_indices
 end
-function partial_min(Card::Penalty, X, α, γ)
-  p = size(X,2)
-  return find(x-> x<0, Card.λ .- γ/2*[dot(α, X[:,j])^2 for j in 1:p])
+
+function partial_min!(indices, Card::Penalty, X, α, γ, cache::Cache)
+  ax = cache.ax
+
+  # compute (α'*X).^2 into pre-allocated scratch space
+  Ac_mul_B!(ax, X, α)
+  map!(abs2, ax, ax)
+
+  # find indices with `λ - γ / 2 * (a'X_j)^2 < 0`
+  n_indices = 0
+  for j = 1:size(X,2)
+    if Card.λ - γ / 2 * ax[j] < 0
+      n_indices += 1
+      indices[n_indices] = j
+    end
+  end
+
+  return n_indices
 end
 
 ##Bias term

--- a/src/SubsetSelection.jl
+++ b/src/SubsetSelection.jl
@@ -164,6 +164,9 @@ function subsetSelection(ℓ::LossFunction, Card::Sparsity, Y, X;
   #Bias
   b = compute_bias(ℓ, Y, X, a, indices, n_indices, γ, intercept, cache)
 
+  #Resize final indices vector to only have relevant entries
+  resize!(indices, n_indices)
+
   return SparseEstimator(ℓ, Card, indices, w, a, b, iter)
 end
 


### PR DESCRIPTION
Thanks for giving me access @jeanpauphilet! I was reading through the code to get familiar with the algorithm before we think about how to use it in Optimal Trees and noticed some small things in the code that were slowing it down. This PR has changes to fix those things that were happening in the hot path of the algorithm and lead to some pretty significant speedups (~3-4x) and reduction in memory usage (~1000x). Most of the speedups work on both julia 0.5 and 0.6, whereas the memory reduction relies on the improvements to [broadcasting in 0.6](https://julialang.org/blog/2017/01/moredots). I've included speed and memory comparisons below. I only considered OLS for now.

Test code:
```julia
using SubsetSelection
using StatsBase
using Base.Test

srand(10)
n = 5000; p = 10000; k = 10;

indices = sort(sample(1:p, StatsBase.Weights(ones(p)/p), k, replace=false));
w = sample(-1:2:1, k);
X = randn(n,p); Y = X[:,indices]*w;

@time Sparse_Regressor = SubsetSelection.subsetSelection(SubsetSelection.OLS(), SubsetSelection.Constraint(10), Y, X, intercept=true)
@time Sparse_Regressor = SubsetSelection.subsetSelection(SubsetSelection.OLS(), SubsetSelection.Constraint(10), Y, X, intercept=false)
@time Sparse_Regressor = SubsetSelection.subsetSelection(SubsetSelection.OLS(), SubsetSelection.Penalty(10000.0), Y, X, intercept=true)
@time Sparse_Regressor = SubsetSelection.subsetSelection(SubsetSelection.OLS(), SubsetSelection.Penalty(10000.0), Y, X, intercept=false)
```

Before - Julia 0.5:
```
  7.601780 seconds (196.27 k allocations: 1.764 GB, 4.10% gc time)
  7.371120 seconds (148.32 k allocations: 1.616 GB, 2.31% gc time)
 13.626151 seconds (2.99 M allocations: 38.130 GB, 21.63% gc time)
 14.106672 seconds (3.03 M allocations: 38.700 GB, 22.31% gc time)
```

After - Julia 0.5:
```
  2.939549 seconds (741.97 k allocations: 879.339 MB, 8.90% gc time)
  2.753066 seconds (739.25 k allocations: 841.021 MB, 3.29% gc time)
  2.972226 seconds (1.11 M allocations: 1.237 GB, 4.59% gc time)
  3.181590 seconds (1.47 M allocations: 1.567 GB, 5.07% gc time)
```

After - Julia 0.6:

```
  2.143580 seconds (10.56 k allocations: 1.339 MiB)
  2.263023 seconds (10.54 k allocations: 1.262 MiB)
  2.153016 seconds (14.94 k allocations: 1.773 MiB)
  2.141344 seconds (19.73 k allocations: 2.065 MiB)
```

Let me know what you think and feel free to drop by to discuss!